### PR TITLE
feat: added drain option to close the encoder properly

### DIFF
--- a/src/encoders/h264.rs
+++ b/src/encoders/h264.rs
@@ -42,6 +42,7 @@ impl EncoderType {
     }
 }
 
+#[derive(Clone, Debug)]
 pub struct EncoderConfig {
     pub input_width: u32,
     pub input_height: u32,

--- a/src/encoders/h264.rs
+++ b/src/encoders/h264.rs
@@ -74,6 +74,21 @@ pub struct H264Encoder {
     output_height: u32,
 }
 
+struct FrameIterator {
+    encoder: AvVideoEncoder,
+    pts: usize,
+}
+
+impl Iterator for FrameIterator {
+    type Item = EncodedFrame;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let curr_pts = self.pts;
+        self.pts += 1;
+        retrieve_nal(&mut self.encoder, curr_pts)
+    }
+}
+
 fn codec_context_as(codec: &AvCodec) -> Result<AvContext, H264EncoderError> {
     unsafe {
         let context_ptr = ffmpeg::ffi::avcodec_alloc_context3(codec.as_ptr());
@@ -199,32 +214,46 @@ impl H264Encoder {
         self.pts_count += 1;
 
         self.encoder.send_frame(&frame).unwrap();
-        let mut encoded_packet = AvPacket::empty();
-        let encoder_res = self.encoder.receive_packet(&mut encoded_packet);
+        retrieve_nal(&mut self.encoder, curr_pts)
+    }
 
-        match encoder_res {
-            Ok(_) => {
-                let encoded_data = encoded_packet.data();
-                if encoded_data.is_none() {
-                    error!("encoder likely dropping frames!! data packet is empty");
-                    None
+    /// Drains this encoder: returns an iterator over the
+    /// remaining NALs and comsumes this object in the process.
+    pub fn drain(mut self) -> Result<impl Iterator<Item = EncodedFrame>, AvError> {
+        self.encoder.send_eof()?;
+        Ok(FrameIterator {
+            encoder: self.encoder,
+            pts: self.pts_count,
+        })
+    }
+}
+
+fn retrieve_nal(encoder: &mut AvVideoEncoder, pts: usize) -> Option<EncodedFrame> {
+    let mut encoded_packet = AvPacket::empty();
+    let encoder_res = encoder.receive_packet(&mut encoded_packet);
+
+    match encoder_res {
+        Ok(_) => {
+            let encoded_data = encoded_packet.data();
+            if encoded_data.is_none() {
+                error!("encoder likely dropping frames!! data packet is empty");
+                None
+            } else {
+                if let Some(nal) = encoded_data {
+                    Some(EncodedFrame {
+                        nal_bytes: bytes::BytesMut::from(nal),
+                        is_keyframe: encoded_packet.is_key(),
+                        duration: encoded_packet.duration(),
+                        pts: pts as i64,
+                    })
                 } else {
-                    if let Some(nal) = encoded_data {
-                        Some(EncodedFrame {
-                            nal_bytes: bytes::BytesMut::from(nal),
-                            is_keyframe: encoded_packet.is_key(),
-                            duration: encoded_packet.duration(),
-                            pts: curr_pts as i64,
-                        })
-                    } else {
-                        None
-                    }
+                    None
                 }
             }
-            Err(e) => {
-                debug!("got ffmpeg encoder error: {e}");
-                None
-            }
+        }
+        Err(e) => {
+            debug!("got ffmpeg encoder error: {e}");
+            None
         }
     }
 }


### PR DESCRIPTION
Original usecase had continuous streams, but now we have one with a finite frame count