### PR TITLE
feat: returning pts of pushed frame along with any new frames

### DIFF
--- a/src/encoders/h264.rs
+++ b/src/encoders/h264.rs
@@ -148,7 +148,7 @@ impl H264Encoder {
     }
 
     #[cfg(feature = "opencv")]
-    pub fn encode_mat(&mut self, input: &Mat) -> Option<EncodedFrame> {
+    pub fn encode_mat(&mut self, input: &Mat) -> (i64, Option<EncodedFrame>) {
         let width = input.cols();
         let height = input.rows();
         let mut out_frame = AvFrame::new(
@@ -171,7 +171,7 @@ impl H264Encoder {
         self.encode(out_frame)
     }
 
-    pub fn encode_raw(&mut self, input: &[u8]) -> Option<EncodedFrame> {
+    pub fn encode_raw(&mut self, input: &[u8]) -> (i64, Option<EncodedFrame>) {
         debug!("input len: {}", input.len());
         let mut out_frame = AvFrame::new(
             AvPixel::YUV420P,
@@ -201,10 +201,11 @@ impl H264Encoder {
         self.encode(out_frame)
     }
 
-    pub fn encode(&mut self, mut frame: AvFrame) -> Option<EncodedFrame> {
-        frame.set_pts(Some(self.pts_count as i64));
+    pub fn encode(&mut self, mut frame: AvFrame) -> (i64, Option<EncodedFrame>) {
+        let pts = self.pts_count as i64;
+        frame.set_pts(Some(pts));
         self.encoder.send_frame(&frame).unwrap();
-        self.retrieve_nal()
+        (pts, self.retrieve_nal())
     }
 
     /// Drains and consumes this encoder

--- a/src/streams/v4l_h264.rs
+++ b/src/streams/v4l_h264.rs
@@ -81,7 +81,7 @@ impl V4lH264Stream {
                 let (m_buf, meta) = stream.next().unwrap();
                 let bytesused = meta.bytesused as usize;
                 // debug!("V4L bytesused: {}", meta.bytesused);
-                if let Some(encoded_frame) = encoder.encode_raw(&m_buf[..bytesused]) {
+                if let (_, Some(encoded_frame)) = encoder.encode_raw(&m_buf[..bytesused]) {
                     tx.blocking_send(encoded_frame.nal_bytes).unwrap();
                 }
             }


### PR DESCRIPTION
Return a key to identify the frame exiting the encoder