### PR TITLE
fix: encoder panic on empty frames

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffutility"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 license = "MPL-2.0"
 description = "A grab bag of video streaming utilities"

--- a/src/encoders/h264.rs
+++ b/src/encoders/h264.rs
@@ -74,8 +74,6 @@ pub enum H264EncoderError {
     FfmpegError(#[from] AvError),
     #[error("failed to alloc avcodec context")]
     AvCodecAllocContextError,
-    #[error("input frame is empty")]
-    EmptyFrame,
 }
 
 pub struct H264Encoder {

--- a/src/encoders/h264.rs
+++ b/src/encoders/h264.rs
@@ -74,6 +74,8 @@ pub enum H264EncoderError {
     FfmpegError(#[from] AvError),
     #[error("failed to alloc avcodec context")]
     AvCodecAllocContextError,
+    #[error("input frame is empty")]
+    EmptyFrame,
 }
 
 pub struct H264Encoder {
@@ -183,6 +185,12 @@ impl H264Encoder {
 
     pub fn encode_raw(&mut self, pts: Option<i64>, input: &[u8]) -> Result<Option<EncodedFrame>, H264EncoderError> {
         debug!("input len: {}", input.len());
+        
+        if input.is_empty() {
+            debug!("Received empty frame, skipping encoding");
+            return Ok(None);
+        }
+        
         let mut out_frame = AvFrame::new(
             AvPixel::YUV420P,
             self.output_width.try_into().unwrap(),


### PR DESCRIPTION
fixing empty frames causing the encoder to panic by looping on empty frames