### PR TITLE
feat: av1 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "ffutility"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -581,6 +581,7 @@ dependencies = [
  "moq-native",
  "opencv",
  "serde",
+ "strum",
  "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
@@ -2180,6 +2181,27 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ffutility"
-version = "0.16.0"
-edition = "2021"
+version = "0.17.0"
+edition = "2024"
 license = "MPL-2.0"
 description = "A grab bag of video streaming utilities"
 homepage = "https://github.com/therishidesai/ffutility"
@@ -19,6 +19,7 @@ bytes = "1.8.0"
 ffmpeg-next = "8.0.0"
 opencv = { version = "0.93.4", optional = true }
 serde = { version = "1.0.215", features = ["derive"] }
+strum = { version = "0.28.0", features = ["derive"] }
 thiserror = "2.0.3"
 tokio = { version = "1.47.1", features = ["sync"], optional = true }
 tokio-stream = { version = "0.1.17", optional = true }

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767892417,
-        "narHash": "sha256-dhhvQY67aboBk8b0/u0XB6vwHdgbROZT3fJAjyNh5Ww=",
+        "lastModified": 1771369470,
+        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
+        "rev": "0182a361324364ae3f436a63005877674cf45efb",
         "type": "github"
       },
       "original": {
@@ -62,11 +62,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1768012928,
-        "narHash": "sha256-HFFVQaux1JoOjEvgBT0ASk1Je+jsipyO5c91FoLMed8=",
+        "lastModified": 1771729765,
+        "narHash": "sha256-HNsDSR5bhLSrIpi9bTb2uTK1qnPo1xFSBxs6YmFyprk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "312b4371e72f644ffcff25b23615195e3b390643",
+        "rev": "be926cb1a76e8450ab2b92121b2e88d09fa4d41c",
         "type": "github"
       },
       "original": {

--- a/src/encoders/mod.rs
+++ b/src/encoders/mod.rs
@@ -1,2 +1,2 @@
-mod h264;
-pub use h264::*;
+mod video;
+pub use video::*;

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -17,6 +17,7 @@ use opencv::{
 };
 
 use serde::{Deserialize, Serialize};
+use strum::{Display, EnumString, IntoStaticStr};
 
 use thiserror::Error;
 
@@ -27,8 +28,20 @@ use tracing::{debug, error};
 pub type FfmpegOptions = Vec<(String, String)>;
 pub type InputType = AvPixel;
 
+/// The video codec standard, independent of the specific encoder implementation.
+#[derive(Serialize, Deserialize, Debug, Display, EnumString, IntoStaticStr, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VideoCodec {
+    #[serde(rename = "h264")]
+    #[strum(serialize = "h264")]
+    H264,
+    #[serde(rename = "av1")]
+    #[strum(serialize = "av1")]
+    Av1,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum EncoderType {
+    // H.264
     #[serde(rename = "libx264")]
     X264,
     #[serde(rename = "h264_nvenc")]
@@ -37,6 +50,11 @@ pub enum EncoderType {
     // NOTE: Only for Jetson NVENC systems. Will not work on any other
     // systems
     H264Nvmpi,
+    // AV1
+    #[serde(rename = "libsvtav1")]
+    SvtAv1,
+    #[serde(rename = "av1_nvenc")]
+    Av1Nvenc,
 }
 
 impl EncoderType {
@@ -45,6 +63,16 @@ impl EncoderType {
             Self::X264 => "libx264",
             Self::H264Nvenc => "h264_nvenc",
             Self::H264Nvmpi => "h264_nvmpi",
+            Self::SvtAv1 => "libsvtav1",
+            Self::Av1Nvenc => "av1_nvenc",
+        }
+    }
+
+    /// Returns the video codec standard for this encoder.
+    pub fn codec(&self) -> VideoCodec {
+        match self {
+            Self::X264 | Self::H264Nvenc | Self::H264Nvmpi => VideoCodec::H264,
+            Self::SvtAv1 | Self::Av1Nvenc => VideoCodec::Av1,
         }
     }
 }
@@ -64,7 +92,7 @@ pub struct EncoderConfig {
 }
 
 #[derive(Error, Debug)]
-pub enum H264EncoderError {
+pub enum VideoEncoderError {
     #[error("PTS was not monotonically increasing: previous PTS: {prev_pts} > PTS: {curr_pts}")]
     PTSNotMonotonic {
         prev_pts: i64,
@@ -76,7 +104,7 @@ pub enum H264EncoderError {
     AvCodecAllocContextError,
 }
 
-pub struct H264Encoder {
+pub struct VideoEncoder {
     encoder: AvVideoEncoder,
     scaler: AvScalingContext,
     prev_pts: Option<i64>,
@@ -87,32 +115,32 @@ pub struct H264Encoder {
     output_height: u32,
 }
 
-fn codec_context_as(codec: &AvCodec) -> Result<AvContext, H264EncoderError> {
+fn codec_context_as(codec: &AvCodec) -> Result<AvContext, VideoEncoderError> {
     unsafe {
         let context_ptr = ffmpeg::ffi::avcodec_alloc_context3(codec.as_ptr());
         if !context_ptr.is_null() {
             Ok(AvContext::wrap(context_ptr, None))
         } else {
-            Err(H264EncoderError::AvCodecAllocContextError)
+            Err(VideoEncoderError::AvCodecAllocContextError)
         }
     }
 }
 
 pub struct EncodedFrame {
-    pub nal_bytes: bytes::BytesMut,
+    pub data: bytes::BytesMut,
     pub is_keyframe: bool,
     pub duration: i64,
     pub pts: Option<i64>,
 }
 
-unsafe impl Send for H264Encoder {}
-unsafe impl Sync for H264Encoder {}
+unsafe impl Send for VideoEncoder {}
+unsafe impl Sync for VideoEncoder {}
 
-impl H264Encoder {
+impl VideoEncoder {
     pub fn new(
         ec: EncoderConfig,
         extra_ffmpeg_opts: &FfmpegOptions,
-    ) -> Result<Self, H264EncoderError> {
+    ) -> Result<Self, VideoEncoderError> {
         let mut extra_opts = AvDictionary::new();
         for opt in extra_ffmpeg_opts {
             extra_opts.set(opt.0.as_str(), opt.1.as_str());
@@ -158,7 +186,7 @@ impl H264Encoder {
     }
 
     #[cfg(feature = "opencv")]
-    pub fn encode_mat(&mut self, pts: Option<i64>, input: &Mat) -> Result<Option<EncodedFrame>, H264EncoderError> {
+    pub fn encode_mat(&mut self, pts: Option<i64>, input: &Mat) -> Result<Option<EncodedFrame>, VideoEncoderError> {
         let width = input.cols();
         let height = input.rows();
         let mut out_frame = AvFrame::new(
@@ -181,7 +209,7 @@ impl H264Encoder {
         self.encode(pts, out_frame)
     }
 
-    pub fn encode_raw(&mut self, pts: Option<i64>, input: &[u8]) -> Result<Option<EncodedFrame>, H264EncoderError> {
+    pub fn encode_raw(&mut self, pts: Option<i64>, input: &[u8]) -> Result<Option<EncodedFrame>, VideoEncoderError> {
         debug!("input len: {}", input.len());
         
         if input.is_empty() {
@@ -217,11 +245,11 @@ impl H264Encoder {
         self.encode(pts, out_frame)
     }
 
-    pub fn encode(&mut self, pts: Option<i64>, mut frame: AvFrame) -> Result<Option<EncodedFrame>, H264EncoderError> {
+    pub fn encode(&mut self, pts: Option<i64>, mut frame: AvFrame) -> Result<Option<EncodedFrame>, VideoEncoderError> {
         if let Some(prev_pts) = self.prev_pts {
             if let Some(curr_pts) = pts {
                 if prev_pts > curr_pts {
-                    return Err(H264EncoderError::PTSNotMonotonic {
+                    return Err(VideoEncoderError::PTSNotMonotonic {
                         prev_pts,
                         curr_pts
                     })
@@ -236,7 +264,7 @@ impl H264Encoder {
     }
 
     /// Drains and consumes this encoder
-    pub fn drain(mut self) -> Result<Vec<EncodedFrame>, H264EncoderError> {
+    pub fn drain(mut self) -> Result<Vec<EncodedFrame>, VideoEncoderError> {
         self.encoder.send_eof()?;
         let mut result = vec![];
         while let Some(nal) = self.retrieve_nal()? {
@@ -247,7 +275,7 @@ impl H264Encoder {
 
     /// Drain a NAL out of the encoder. Typically not used directly,
     /// except after `begin_drain`.
-    fn retrieve_nal(&mut self) -> Result<Option<EncodedFrame>, H264EncoderError> {
+    fn retrieve_nal(&mut self) -> Result<Option<EncodedFrame>, VideoEncoderError> {
         let mut encoded_packet = AvPacket::empty();
         let encoder_res = self.encoder.receive_packet(&mut encoded_packet);
 
@@ -260,7 +288,7 @@ impl H264Encoder {
                 } else {
                     if let Some(nal) = encoded_data {
                         Ok(Some(EncodedFrame {
-                            nal_bytes: bytes::BytesMut::from(nal),
+                            data: bytes::BytesMut::from(nal),
                             is_keyframe: encoded_packet.is_key(),
                             duration: encoded_packet.duration(),
                             pts: encoded_packet.pts(),

--- a/src/streams/v4l_h264.rs
+++ b/src/streams/v4l_h264.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 
 use bytes::{Bytes, BytesMut};
 
-use crate::encoders::{EncoderConfig, EncoderType, FfmpegOptions, H264Encoder, InputType};
+use crate::encoders::{EncoderConfig, EncoderType, FfmpegOptions, VideoEncoder, InputType};
 
 use ffmpeg_next::util::format::Pixel as AvPixel;
 
@@ -96,20 +96,20 @@ impl V4lH264Stream {
                 let mut f = File::create("loading-video.h264").unwrap();
 
                 let mut loading_encoder =
-                    H264Encoder::new(loading_ec, &loading_ffmpeg_opts).unwrap();
+                    VideoEncoder::new(loading_ec, &loading_ffmpeg_opts).unwrap();
                 let mut nal_frames = Vec::new();
                 loop {
                     if let Some(encoded_frame) = loading_encoder
                         .encode_raw(Some(0), &loading_image.data)
                         .unwrap()
                     {
-                        nal_frames.push(encoded_frame.nal_bytes.freeze());
+                        nal_frames.push(encoded_frame.data.freeze());
                         break;
                     }
                 }
 
                 for encoded_frame in loading_encoder.drain().unwrap() {
-                    let frame = encoded_frame.nal_bytes.clone().freeze();
+                    let frame = encoded_frame.data.clone().freeze();
                     f.write_all(&frame);
                     f.flush();
                     nal_frames.push(frame);
@@ -173,7 +173,7 @@ impl V4lH264Stream {
             ));
 
             let mut pts: i64 = 0;
-            let mut encoder = H264Encoder::new(ec, &live_ffmpeg_opts).unwrap();
+            let mut encoder = VideoEncoder::new(ec, &live_ffmpeg_opts).unwrap();
 
             loop {
                 // TODO: Better error handling
@@ -184,7 +184,7 @@ impl V4lH264Stream {
                         if let Some(encoded_frame) =
                             encoder.encode_raw(Some(pts), &m_buf[..bytesused]).unwrap()
                         {
-                            tx.blocking_send(Ok(encoded_frame.nal_bytes)).unwrap();
+                            tx.blocking_send(Ok(encoded_frame.data)).unwrap();
                         }
                         pts += 1;
                     }


### PR DESCRIPTION
Add av1 support, with software encoder via `libsvtav1` and the nvenc variant too. Makes `H264Encoder` instead be a generic `VideoEncoder`. h.264 specific names are also genericized. 