### PR TITLE
chore: expose opt consistently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "ffutility"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffutility"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "MPL-2.0"
 description = "A grab bag of video streaming utilities"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,98 @@
 # ffutility
 
-ffutility (prononouced futility) is a grab bag of tools to work with video encoding in rust.
+ffutility (pronounced futility) is a grab bag of tools to work with video encoding in rust.
+
+## EncoderConfig
+
+`EncoderConfig` has structural fields for buffer allocation and codec setup:
+
+- `input_width`, `input_height` — input frame dimensions
+- `output_width`, `output_height` — encoded output dimensions
+- `framerate` — frames per second
+- `enc_type` — encoder selection (`EncoderType`)
+- `input_type` — input pixel format (`InputType` / ffmpeg `Pixel`)
+
+All encoder tuning is configured via `opts: Vec<(String, String)>`, passed directly as an ffmpeg dictionary to `avcodec_open2`. Any option valid for `ffmpeg -option value` works here.
+
+Some options are mutually exclusive or only apply to specific encoders/modes. Invalid or inapplicable options are silently ignored by ffmpeg. Run `ffmpeg -h encoder=<name>` to see all options for a given encoder.
+
+Full option references:
+- [Generic codec options](https://ffmpeg.org/ffmpeg-codecs.html#Codec-Options)
+- [libx264](https://ffmpeg.org/ffmpeg-codecs.html#libx264_002c-libx264rgb)
+- [NVENC](https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/ffmpeg-with-nvidia-gpu/index.html)
+- [SVT-AV1](https://gitlab.com/AOMediaCodec/SVT-AV1/-/blob/master/Docs/Parameters.md)
+
+### Common
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `b` | Bitrate in bits/sec. Ignored with `rc=constqp`. | `"7500000"` |
+| `g` | GOP size in frames | `"16"` |
+| `bf` | Max B-frames. `"0"` to disable. | `"2"` |
+| `qp` | Constant QP. Lower = higher quality. | `"20"` |
+| `preset` | Speed/quality tradeoff. Values are encoder-specific (see Presets). | `"p5"` |
+
+#### Presets
+
+| Encoder | Values |
+|---------|--------|
+| `libx264` / `libx265` | `ultrafast`, `superfast`, `veryfast`, `faster`, `fast`, `medium`, `slow`, `slower`, `veryslow` |
+| `h264_nvenc` / `av1_nvenc` | `p1` through `p7` |
+| `libsvtav1` | `0` (slowest) through `13` (fastest) |
+
+### NVENC Specific
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `rc` | Rate control: `constqp`, `vbr`, `cbr` | `"constqp"` |
+| `tune` | `hq`, `ll`, `ull`, `lossless` | `"hq"` |
+| `rc-lookahead` | Frames to look ahead for rate control | `"10"` |
+| `b_ref_mode` | B-frames as references: `disabled`, `each`, `middle` | `"middle"` |
+| `spatial-aq` | Spatial adaptive quantization. `"1"` to enable. | `"1"` |
+| `temporal-aq` | Temporal adaptive quantization. `"1"` to enable. | `"1"` |
+| `aq-strength` | AQ strength 1 (low) to 15 (aggressive). Only with `spatial-aq`. | `"8"` |
+| `multipass` | `disabled`, `qres`, `fullres` | `"qres"` |
+| `zerolatency` | No reordering delay. `"1"` to enable. | `"1"` |
+| `forced-idr` | Force keyframes as IDR frames. `"1"` to enable. | `"1"` |
+
+### H.264 Specific
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `profile` | `baseline`, `main`, `high` | `"high"` |
+| `tune` | `film`, `animation`, `grain`, `stillimage`, `zerolatency`, etc. (libx264 only) | `"zerolatency"` |
+| `x264-params` | Raw params as `key=value:key=value` | `"repeat-headers=1"` |
+| `crf` | Constant rate factor, 0-51 (libx264 only) | `"23"` |
+
+### AV1 Specific
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `tier` | `main` or `high` (av1_nvenc) | `"high"` |
+| `highbitdepth` | 10-bit encode for 8-bit input (av1_nvenc). `"1"` to enable. | `"1"` |
+| `crf` | Constant rate factor, 0-63 (libsvtav1 only) | `"30"` |
+| `svtav1-params` | Raw params as `key=value:key=value` (libsvtav1 only) | `"film-grain=8"` |
+
+### Example
+
+```rust
+let ec = EncoderConfig {
+    input_width: 1920,
+    input_height: 1080,
+    output_width: 1920,
+    output_height: 1080,
+    enc_type: EncoderType::Av1Nvenc,
+    input_type: InputType::BGR24,
+    opts: vec![
+        ("preset".into(), "p5".into()),
+        ("rc".into(), "constqp".into()),
+        ("qp".into(), "20".into()),
+        ("g".into(), "16".into()),
+        ("bf".into(), "2".into()),
+        ("b_ref_mode".into(), "middle".into()),
+        ("rc-lookahead".into(), "10".into()),
+    ],
+};
+
+let encoder = VideoEncoder::new(ec).expect("failed to create encoder");
+```

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -5,7 +5,6 @@ use ffmpeg::codec::packet::Packet as AvPacket;
 use ffmpeg::software::scaling::{context::Context as AvScalingContext, flag::Flags};
 use ffmpeg::util::format::Pixel as AvPixel;
 use ffmpeg::util::frame::Video as AvFrame;
-use ffmpeg::util::rational::Rational;
 use ffmpeg::Dictionary as AvDictionary;
 use ffmpeg::Error as AvError;
 use ffmpeg_next as ffmpeg;
@@ -83,12 +82,9 @@ pub struct EncoderConfig {
     pub input_height: u32,
     pub output_width: u32,
     pub output_height: u32,
-    pub framerate: u32,
-    pub gop: Option<u32>,
-    pub bitrate: usize,
-    pub disable_b_frames: bool,
     pub enc_type: EncoderType,
     pub input_type: InputType,
+    pub opts: FfmpegOptions,
 }
 
 #[derive(Error, Debug)]
@@ -137,13 +133,10 @@ unsafe impl Send for VideoEncoder {}
 unsafe impl Sync for VideoEncoder {}
 
 impl VideoEncoder {
-    pub fn new(
-        ec: EncoderConfig,
-        extra_ffmpeg_opts: &FfmpegOptions,
-    ) -> Result<Self, VideoEncoderError> {
-        let mut extra_opts = AvDictionary::new();
-        for opt in extra_ffmpeg_opts {
-            extra_opts.set(opt.0.as_str(), opt.1.as_str());
+    pub fn new(ec: EncoderConfig) -> Result<Self, VideoEncoderError> {
+        let mut opts = AvDictionary::new();
+        for (k, v) in &ec.opts {
+            opts.set(k, v);
         }
 
         let ffmpeg_codec = ffmpeg::encoder::find_by_name(ec.enc_type.as_str()).unwrap();
@@ -152,16 +145,7 @@ impl VideoEncoder {
         ffmpeg_vid_encoder.set_width(ec.output_width);
         ffmpeg_vid_encoder.set_height(ec.output_height);
         ffmpeg_vid_encoder.set_format(AvPixel::YUV420P);
-        ffmpeg_vid_encoder.set_frame_rate(Some((ec.framerate as i32, 1)));
-        ffmpeg_vid_encoder.set_time_base(Rational(1, ec.framerate as i32));
-        ffmpeg_vid_encoder.set_bit_rate(ec.bitrate as usize);
-        if ec.disable_b_frames {
-            ffmpeg_vid_encoder.set_max_b_frames(0_usize);
-        }
-        if let Some(gop) = ec.gop {
-            ffmpeg_vid_encoder.set_gop(gop);
-        }
-        let encoder = ffmpeg_vid_encoder.open_with(extra_opts)?;
+        let encoder = ffmpeg_vid_encoder.open_with(opts)?;
 
         let scaler = AvScalingContext::get(
             ec.input_type,
@@ -219,14 +203,14 @@ impl VideoEncoder {
         
         let mut out_frame = AvFrame::new(
             AvPixel::YUV420P,
-            self.output_width.try_into().unwrap(),
-            self.output_height.try_into().unwrap(),
+            self.output_width,
+            self.output_height,
         );
 
         let mut in_frame = AvFrame::new(
             self.input_type,
-            self.input_width.try_into().unwrap(),
-            self.input_height.try_into().unwrap(),
+            self.input_width,
+            self.input_height,
         );
 
         if in_frame.planes() > 1 {
@@ -246,15 +230,11 @@ impl VideoEncoder {
     }
 
     pub fn encode(&mut self, pts: Option<i64>, mut frame: AvFrame) -> Result<Option<EncodedFrame>, VideoEncoderError> {
-        if let Some(prev_pts) = self.prev_pts {
-            if let Some(curr_pts) = pts {
-                if prev_pts > curr_pts {
-                    return Err(VideoEncoderError::PTSNotMonotonic {
-                        prev_pts,
-                        curr_pts
-                    })
-                }
-            }
+        if let (Some(prev_pts), Some(curr_pts)) = (self.prev_pts, pts) && prev_pts > curr_pts {
+            return Err(VideoEncoderError::PTSNotMonotonic {
+                prev_pts,
+                curr_pts,
+            });
         }
 
         frame.set_pts(pts);

--- a/src/streams/v4l_h264.rs
+++ b/src/streams/v4l_h264.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 
 use bytes::{Bytes, BytesMut};
 
-use crate::encoders::{EncoderConfig, EncoderType, FfmpegOptions, VideoEncoder, InputType};
+use crate::encoders::{EncoderConfig, EncoderType, FfmpegOptions, InputType, VideoEncoder};
 
 use ffmpeg_next::util::format::Pixel as AvPixel;
 
@@ -71,13 +71,6 @@ impl V4lH264Stream {
         let (tx, rx) = mpsc::channel::<Result<BytesMut, io::Error>>(10);
 
         std::thread::spawn(move || {
-            let mut loading_ffmpeg_opts = FfmpegOptions::new();
-            loading_ffmpeg_opts.push((String::from("preset"), String::from("medium")));
-            loading_ffmpeg_opts.push((String::from("tune"), String::from("stillimage")));
-            loading_ffmpeg_opts.push((
-                String::from("x264-params"),
-                String::from("repeat-headers=1:keyint=1:min-keyint=1:scenecut=0"),
-            ));
             // TODO: better error handling, should close the channel correctly instead of exploding
             let cached_loading_frames = cfg.loading_image.as_ref().map(|loading_image| {
                 let loading_ec = EncoderConfig {
@@ -85,18 +78,21 @@ impl V4lH264Stream {
                     input_height: loading_image.input_height,
                     output_width: cfg.output_width,
                     output_height: cfg.output_height,
-                    framerate: 10,
-                    gop: Some(1),
-                    bitrate: 1000000,
-                    disable_b_frames: true,
                     enc_type: EncoderType::X264,
                     input_type: loading_image.input_type,
+                    opts: vec![
+                        ("preset".into(), "medium".into()),
+                        ("tune".into(), "stillimage".into()),
+                        ("x264-params".into(), "repeat-headers=1:keyint=1:min-keyint=1:scenecut=0".into()),
+                        ("g".into(), "1".into()),
+                        ("b".into(), "1000000".into()),
+                        ("bf".into(), "0".into()),
+                    ],
                 };
 
                 let mut f = File::create("loading-video.h264").unwrap();
 
-                let mut loading_encoder =
-                    VideoEncoder::new(loading_ec, &loading_ffmpeg_opts).unwrap();
+                let mut loading_encoder = VideoEncoder::new(loading_ec).unwrap();
                 let mut nal_frames = Vec::new();
                 loop {
                     if let Some(encoded_frame) = loading_encoder
@@ -150,30 +146,28 @@ impl V4lH264Stream {
             let format = v4l_dev.format().unwrap();
             debug!("V4L Format: {:?}", format);
             // TODO: Make this EncoderConfig settable by the user
+            let mut opts = vec![
+                ("b".into(), cfg.bitrate.to_string()),
+                ("bf".into(), "0".into()),
+            ];
+            opts.extend(ffmpeg_opts.clone());
+            // repeat-headers=1 ensures SPS/PPS are emitted regularly.
+            // Critical for seamless transitions from overlay to live feed,
+            // as the decoder needs fresh SPS/PPS headers to reinitialize.
+            opts.push(("x264-params".into(), "repeat-headers=1".into()));
+
             let ec = EncoderConfig {
                 input_width: format.width,
                 input_height: format.height,
                 output_width: cfg.output_width,
                 output_height: cfg.output_height,
-                framerate: 15,
-                gop: None,
-                bitrate: cfg.bitrate,
-                disable_b_frames: true,
                 enc_type: EncoderType::X264,
                 input_type,
+                opts,
             };
 
-            // Add repeat-headers=1 to ensure SPS/PPS are emitted regularly.
-            // This is critical for seamless transitions from overlay to live feed,
-            // as the decoder needs fresh SPS/PPS headers to reinitialize.
-            let mut live_ffmpeg_opts = ffmpeg_opts.clone();
-            live_ffmpeg_opts.push((
-                String::from("x264-params"),
-                String::from("repeat-headers=1"),
-            ));
-
             let mut pts: i64 = 0;
-            let mut encoder = VideoEncoder::new(ec, &live_ffmpeg_opts).unwrap();
+            let mut encoder = VideoEncoder::new(ec).unwrap();
 
             loop {
                 // TODO: Better error handling


### PR DESCRIPTION
Remove separate config fields for gop, bitrate, and b frames. These can all be controlled via the `FfmpegOptions` struct as kv pairs. This puts the configuration burden on the user to understand and know the options, but presents a consistent way of configuring all the myriad options that are available. To that end, I've added syntax to the README for some common options that users may want to know of. 