### PR TITLE
fix(encoders): set encoder time base

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,7 +571,7 @@ dependencies = [
 
 [[package]]
 name = "ffutility"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ffutility"
-version = "0.18.0"
+version = "0.18.1"
 edition = "2024"
 license = "MPL-2.0"
 description = "A grab bag of video streaming utilities"

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -5,6 +5,7 @@ use ffmpeg::codec::packet::Packet as AvPacket;
 use ffmpeg::software::scaling::{context::Context as AvScalingContext, flag::Flags};
 use ffmpeg::util::format::Pixel as AvPixel;
 use ffmpeg::util::frame::Video as AvFrame;
+use ffmpeg::util::rational::Rational;
 use ffmpeg::Dictionary as AvDictionary;
 use ffmpeg::Error as AvError;
 use ffmpeg_next as ffmpeg;
@@ -134,8 +135,22 @@ unsafe impl Sync for VideoEncoder {}
 
 impl VideoEncoder {
     pub fn new(ec: EncoderConfig) -> Result<Self, VideoEncoderError> {
+        // "framerate" is a ffutility-level pseudo-option (frames/sec): it sets
+        // the encoder frame rate + time base rather than being forwarded to
+        // the codec. A valid time base is mandatory — libx264 aborts
+        // avcodec_open2 with EINVAL ("The encoder timebase is not set") without
+        // one. Defaults to 30 when unset.
+        let mut fps: i32 = 30;
         let mut opts = AvDictionary::new();
         for (k, v) in &ec.opts {
+            if k == "framerate" {
+                if let Ok(parsed) = v.parse::<i32>() {
+                    if parsed > 0 {
+                        fps = parsed;
+                    }
+                }
+                continue;
+            }
             opts.set(k, v);
         }
 
@@ -145,6 +160,8 @@ impl VideoEncoder {
         ffmpeg_vid_encoder.set_width(ec.output_width);
         ffmpeg_vid_encoder.set_height(ec.output_height);
         ffmpeg_vid_encoder.set_format(AvPixel::YUV420P);
+        ffmpeg_vid_encoder.set_frame_rate(Some(Rational(fps, 1)));
+        ffmpeg_vid_encoder.set_time_base(Rational(1, fps));
         let encoder = ffmpeg_vid_encoder.open_with(opts)?;
 
         let scaler = AvScalingContext::get(

--- a/src/encoders/video.rs
+++ b/src/encoders/video.rs
@@ -135,11 +135,6 @@ unsafe impl Sync for VideoEncoder {}
 
 impl VideoEncoder {
     pub fn new(ec: EncoderConfig) -> Result<Self, VideoEncoderError> {
-        // "framerate" is a ffutility-level pseudo-option (frames/sec): it sets
-        // the encoder frame rate + time base rather than being forwarded to
-        // the codec. A valid time base is mandatory — libx264 aborts
-        // avcodec_open2 with EINVAL ("The encoder timebase is not set") without
-        // one. Defaults to 30 when unset.
         let mut fps: i32 = 30;
         let mut opts = AvDictionary::new();
         for (k, v) in &ec.opts {

--- a/src/streams/v4l_h264.rs
+++ b/src/streams/v4l_h264.rs
@@ -81,6 +81,7 @@ impl V4lH264Stream {
                     enc_type: EncoderType::X264,
                     input_type: loading_image.input_type,
                     opts: vec![
+                        ("framerate".into(), "10".into()),
                         ("preset".into(), "medium".into()),
                         ("tune".into(), "stillimage".into()),
                         ("x264-params".into(), "repeat-headers=1:keyint=1:min-keyint=1:scenecut=0".into()),
@@ -147,6 +148,7 @@ impl V4lH264Stream {
             debug!("V4L Format: {:?}", format);
             // TODO: Make this EncoderConfig settable by the user
             let mut opts = vec![
+                ("framerate".into(), "15".into()),
                 ("b".into(), cfg.bitrate.to_string()),
                 ("bf".into(), "0".into()),
             ];


### PR DESCRIPTION
0.18 dropped set_frame_rate/set_time_base in VideoEncoder::new, so libx264 aborts avcodec_open2 with EINVAL. Restore via a stripped 'framerate' pseudo-opt (default 30).
